### PR TITLE
add error handling to csv reader

### DIFF
--- a/scraper/components/parsers/base_parser.py
+++ b/scraper/components/parsers/base_parser.py
@@ -30,6 +30,7 @@ class Parser(abc.ABC):
         """ Takes a %Y%m%d formatted date and outputs it to "%Y-%m-%d" """
         return dt.strptime(datestr, "%Y%m%d").strftime("%Y-%m-%d")
 
+    @abc.abstractmethod
     def process_response_to_csv(self, response):
         """
         Takes the response object from a performed requests call and should
@@ -46,10 +47,6 @@ class Parser(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def parse_headers(self, header):
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def parse_row(self, row):
         raise NotImplementedError
 
@@ -58,13 +55,11 @@ class Parser(abc.ABC):
 
         # first line is the header. cache it
         self.cache_header(next(reader))
-        # TODO: This comes from base_fetcher. adapt to actual parsing
-        # yield the rows for processing
+
         for row in reader:
             data = row[0].split(separator)
-            # print(data)
             if len(data) <= 1:
-                return
+                continue
 
             ticker = self.extract_ticker_from_row(data)
             if len(self.settings.tickers) == 0 or ticker in self.settings.tickers:

--- a/scraper/components/parsers/finra_parser.py
+++ b/scraper/components/parsers/finra_parser.py
@@ -6,7 +6,7 @@ class FinraParser(Parser):
         super().__init__(settings, debug)
 
     def process_response_to_csv(self, response):
-        return csv.reader(codecs.iterdecode(response.iter_lines(), 'utf-8'))
+        return csv.reader(codecs.iterdecode(response.iter_lines(), 'utf-8', errors="replace"))
 
     def extract_ticker_from_row(self, row_data):
         return row_data[1]

--- a/scraper/components/parsers/secftd_parser.py
+++ b/scraper/components/parsers/secftd_parser.py
@@ -12,10 +12,11 @@ class SecFtdParser(Parser):
         zf = ZipFile(BytesIO(response.content), 'r')
         # Zip should contain only one file
         filename = zf.namelist()[0]
+
         if not filename:
             raise ValueError("Zip was missing the content!")
 
-        return csv.reader(codecs.iterdecode(zf.open(filename), 'utf-8'))
+        return csv.reader(codecs.iterdecode(zf.open(filename), 'utf-8', errors="replace"))
 
     def extract_ticker_from_row(self, row_data):
         return row_data[2]


### PR DESCRIPTION
we were getting an encoding error. added the eror='replace' argument to the reader. Seems like it's fixed