### PR TITLE
Fetchers & StockScraper refactor

### DIFF
--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -1,3 +1,4 @@
 from scraper.settings import Settings
 from scraper.stocks import StockScraper
+from scraper import components
 from scraper import utils

--- a/scraper/components/__init__.py
+++ b/scraper/components/__init__.py
@@ -1,3 +1,3 @@
-from scraper.components.fetchers import FinraFetcher, SecFtdFetcher
-from scraper.components.parsers import FinraParser, SecFtdParser
-from scraper.components.writers import SingleFileWriter, SingleTickerWriter
+from scraper.components import fetchers
+from scraper.components import parsers
+from scraper.components import writers

--- a/scraper/components/fetchers/__init__.py
+++ b/scraper/components/fetchers/__init__.py
@@ -1,2 +1,3 @@
-from scraper.components.fetchers.finra_fetcher import FinraFetcher
-from scraper.components.fetchers.secftd_fetcher import SecFtdFetcher
+from scraper.components.fetchers.finra_fetcher import FinraFetcher as Finra
+from scraper.components.fetchers.secftd_fetcher import SecFtdFetcher as SecFtd
+from scraper.components.fetchers.nasdaq_fetcher import NasdaqFetcher as Nasdaq

--- a/scraper/components/fetchers/base_fetcher.py
+++ b/scraper/components/fetchers/base_fetcher.py
@@ -9,49 +9,91 @@ from scraper import utils
 
 class Fetcher(abc.ABC):
     def __init__(self, settings, debug=False):
+        self.settings = settings
         self.tickers = settings.tickers or []
-        self.start_date = settings.start_date or dt(2020,5,1).date()
+        self.start_date = settings.start_date or dt(2019,1,1).date()
         self.end_date = settings.end_date or datetime.now().date()
 
         self._debug = debug
         self._done = False
 
+        self.processed = []
+        # TODO: Implement the option to change it. This is needed to loop
+        # the tickers when the fetcherss that work on ticker and not on date
+        # loops (i.e. nasdaq) need to grab stuff.
+        self.loop_tickers_not_dates = False
+
     # @abc.abstractmethod
-    def daterange(self):
+    def date_range(self):
         """Generate the date iterator to loop all the data to fetch"""
         for n in range(int((self.end_date - self.start_date).days)):
             yield self.start_date + timedelta(n)
 
     def done(self):
         self._done = True
-
-    def process_file_to_csv(self, response):
-        """
-        Takes the raw output from the response and outputs a csv readable stream
-        """
-        return codecs.iterdecode(response.iter_lines(), 'utf-8')
+        self.processed = []
 
     @abc.abstractmethod
-    def make_url(self, date):
+    def make_url(self, *args, **kwargs):
         raise NotImplementedError
 
-    def run(self, show_progress=True, *args, **kwargs):
-        self._done = False
-        if show_progress:
-            i = 0   # used for progress_bar
-            dates_count = len(list(self.daterange()))
-            utils.progress_bar(0, dates_count, length = 50)
+    # if the provided url is in the processed list return None, otherwise
+    # add it and return it.
+    def validate_new_url(self, url):
+        if url in self.processed:
+            return None
+        self.processed.append(url)
+        return url
 
-        for date in self.daterange():
-            for url in self.make_url(date):
-                if not url: continue
+    def tickers_range(self):
+        for ticker in self.settings.tickers:
+            yield ticker
 
-                with closing(requests.get(url, stream=True)) as response:
+    def make_requests(self, *args, **kwargs):
+        # NOTE: make_url methods MUST take the first (and only?) argument as
+        # the one they use to create the actual url, either the "current date".
+        # or "current ticker" that's being processed
+        # If in the future this breaks for some reason (i.e. a fetcher needs
+        # more info from a loop) we can revert to looping the dates and moving
+        # specific loops inside the make_url methods (i.e. nasdaq.make_url will
+        # loop the tickers from settings to generate them).
+        # This would be less efficient but would work just fine.
+        main_loop = self.tickers_range if self.loop_tickers_not_dates else self.date_range
+
+        for url_source in main_loop():
+            for url in self.make_url(url_source, *args, **kwargs):
+                # If the url is already been processed skip it
+                if not self.validate_new_url(url):
+                    continue
+
+
+                with closing(requests.get(url)) as response:
                     if response.status_code == 200:
                         yield response
+                    yield None
 
-            if show_progress:
-                utils.progress_bar(i + 1, dates_count, length = 50)
-                i += 1
+    def run(self, show_progress=True, tickers=None, *args, **kwargs):
+        self._done = False
+        max_progr = self.get_progress_max_value()
+        progress = self.progress_bar(show_progress, -1, max_progr)
+
+        for response in self.make_requests(*args, **kwargs):
+            if not response:
+                progress = self.progress_bar(show_progress, progress, max_progr)
+                continue
+
+            yield response
+            progress = self.progress_bar(show_progress, progress, max_progr)
 
         self.done()
+
+    def progress_bar(self, show_progress, curr, max):
+        curr +=1
+        if show_progress:
+            utils.progress_bar(curr, max, length = 50)
+        return curr
+
+    def get_progress_max_value(self):
+        if self.loop_tickers_not_dates:
+            return len(self.settings.tickers)
+        return len(list(self.date_range()))

--- a/scraper/components/fetchers/finra_fetcher.py
+++ b/scraper/components/fetchers/finra_fetcher.py
@@ -9,8 +9,10 @@ class FinraFetcher(Fetcher):
     def __init__(self, settings, debug=False):
         super().__init__(settings, debug)
 
-    def make_url(self, date):
+    def make_url(self, date, *args, **kwargs):
         """ Get the url for the specified date for the given source"""
         date = date.strftime("%Y%m%d")
         # return self.URL_BASE + str(date) + self.URL_END
-        yield self.URL_BASE + str(date) + self.URL_END
+        url = "{}{}{}".format(self.URL_BASE, date, self.URL_END)
+        
+        yield url

--- a/scraper/components/fetchers/nasdaq_fetcher.py
+++ b/scraper/components/fetchers/nasdaq_fetcher.py
@@ -7,10 +7,16 @@ class NasdaqFetcher(Fetcher):
 
     def __init__(self, settings, debug=False):
         super().__init__(settings, debug)
+        self.loop_tickers_not_dates = True
 
     def make_url(self, ticker, *args, **kwargs):
-        """ Get the url for the specified date for the given source"""
+        """ Get the url for the specified date for the given source """
+        
+        # if ticker not in self.settings.tickers:
+        #     raise ValueError(f'NasdaqFetcher: where does ticker '{ticker}' comes from?')
+
         def tostr(d):
+            """ Format the date in nasdaq url format type """
             return d.strftime("%Y-%m-%d")
 
         start_ = self.start_date
@@ -18,5 +24,7 @@ class NasdaqFetcher(Fetcher):
         # timedelta object -> number of days
         limit = (end_ - start_).days
 
-        # return self.URL_BASE + str(date) + self.URL_END
-        yield self.URL.format(start=tostr(start_), end=tostr(end_), limit=limit, ticker=ticker)
+        url = self.URL.format(start=tostr(start_), end=tostr(end_), limit=limit, ticker=ticker)
+
+        yield url
+

--- a/scraper/components/fetchers/nasdaq_fetcher.py
+++ b/scraper/components/fetchers/nasdaq_fetcher.py
@@ -1,0 +1,22 @@
+from scraper.components.fetchers.base_fetcher import Fetcher
+# import scraper.utils as utils
+
+class NasdaqFetcher(Fetcher):
+
+    URL = "https://api.nasdaq.com/api/quote/{ticker}/historical?assetclass=stocks&fromdate={start}&limit={limit}&todate={end}"
+
+    def __init__(self, settings, debug=False):
+        super().__init__(settings, debug)
+
+    def make_url(self, ticker, *args, **kwargs):
+        """ Get the url for the specified date for the given source"""
+        def tostr(d):
+            return d.strftime("%Y-%m-%d")
+
+        start_ = self.start_date
+        end_ = self.end_date
+        # timedelta object -> number of days
+        limit = (end_ - start_).days
+
+        # return self.URL_BASE + str(date) + self.URL_END
+        yield self.URL.format(start=tostr(start_), end=tostr(end_), limit=limit, ticker=ticker)

--- a/scraper/components/fetchers/secftd_fetcher.py
+++ b/scraper/components/fetchers/secftd_fetcher.py
@@ -17,11 +17,6 @@ class SecFtdFetcher(Fetcher):
 
     def __init__(self, settings, debug=False):
         super().__init__(settings, debug)
-        self.processed = []
-    
-    def done(self):
-        super().done()
-        self.processed = []
 
     def make_url(self, date, *args, **kwargs):
         date = date.strftime("%Y%m")
@@ -31,9 +26,6 @@ class SecFtdFetcher(Fetcher):
             # Since we receive ALL days from our caller and in this case we work
             # on a monthly basis, we check if the url has already been processed
             # and if so sky to the next one until we reach a new month
-            if url in self.processed:
-                continue
 
-            self.processed.append(url)
             yield url
 

--- a/scraper/components/parsers/__init__.py
+++ b/scraper/components/parsers/__init__.py
@@ -1,2 +1,2 @@
-from scraper.components.parsers.finra_parser import FinraParser
-from scraper.components.parsers.secftd_parser import SecFtdParser
+from scraper.components.parsers.finra_parser import FinraParser as Finra
+from scraper.components.parsers.secftd_parser import SecFtdParser as SecFtd

--- a/scraper/components/writers/__init__.py
+++ b/scraper/components/writers/__init__.py
@@ -1,2 +1,2 @@
-from scraper.components.writers.single_file_writer import SingleFileWriter
-from scraper.components.writers.single_ticker_writer import SingleTickerWriter
+from scraper.components.writers.single_file_writer import SingleFileWriter as SingleFile
+from scraper.components.writers.single_ticker_writer import SingleTickerWriter as MultiFile


### PR DESCRIPTION
refactor fetchers logic to a more scalable way

add option to loop either the dates or the tickers when generating the urls (child class should set `self.loop_tickers_not_dates=True`)
started working on nasdaq fetcher and parser but encountered an api-key related issue (see  99ec88f)