### PR TITLE
add --cov to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
 install:
   - pip install -r requirements.txt
 script:
-  - pytest tests
+  - pytest --cov
 after_success:
   - codecov


### PR DESCRIPTION
test travis config to allow pytest to generate the coverage.xml for codecov