### PR TITLE
menu generation on cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /finra_scraper_v1.1.zip
 /data/
 /.vscode
-/testing.py
+local_testing/
 scraper/settings/attribute/
 
 # Byte-compiled / optimized / DLL files

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -18,6 +18,8 @@ def start():
     manager.register_writer(
         OUTPUT_TYPE.SINGLE_TICKER, writers.MultiFile)
 
+    manager.register_dialect('default', delimiter='|')
+
     settings = Settings()
 
     os.system('clear')

--- a/cli/dates.py
+++ b/cli/dates.py
@@ -18,7 +18,7 @@ def description():
     return ("Here you can specify your date range, that will be between"
             f"your {start} and {end} dates.\n"
             f"{note}\nBe sure to have your {start} date set before in time"
-            f"than the {end} date.")
+            f"than the {end} date.\n")
 
 
 def run(settings):

--- a/cli/dates.py
+++ b/cli/dates.py
@@ -4,9 +4,9 @@ from cli import utils
 
 def get_menu():
     return [
+        ("[x] Back", utils.handle_go_back),
         ("[s] Change Start date", handle_start_date),
         ("[e] Change End date", handle_end_date),
-        ("[x] Back", utils.handle_go_back),
     ]
 
 

--- a/cli/entry.py
+++ b/cli/entry.py
@@ -7,12 +7,12 @@ from scraper import App
 
 def get_menu():
     return [
+        ("[r] Run scraper", handle_run_scraper),
+        ("[x] Save and Exit", handle_exit),
         ("[d] Change Date range", handle_dates_menu),
         ("[o] Change Output settings", handle_output_menu),
         ("[s] Edit sources", handle_sources_menu),
         ("[t] Edit Tickers", handle_tickers_menu),
-        ("[r] Run scraper", handle_run_scraper),
-        ("[x] Save and Exit", handle_exit),
     ]
 
 

--- a/cli/output.py
+++ b/cli/output.py
@@ -84,7 +84,7 @@ def handle_csv_dialect(settings):
         )
     choice = csv_menu.show()
 
-    if choice == utils.BACK:
+    if choice == utils.BACK_TXT:
         return False
 
     try:

--- a/cli/output.py
+++ b/cli/output.py
@@ -7,11 +7,11 @@ from cli import utils
 
 def get_menu():
     return [
+        ("[x] Back", utils.handle_go_back),
         ("[t] Change output file type", handle_output_type),
         ("[p] Change output path", handle_output_path),
         ("[f] Change output file format", handle_output_filename),
         ("[d] Change CSV format", handle_csv_dialect),
-        ("[x] Back", utils.handle_go_back),
     ]
 
 

--- a/cli/output.py
+++ b/cli/output.py
@@ -49,7 +49,9 @@ def handle_output_type(settings):
     output_type_items = (utils.BACK_TXT, *manager.get_outputs())
 
     output_menu = TerminalMenu(
-        menu_entries=[option for option in output_type_items])
+        menu_entries=output_type_items,
+        cursor_index=output_type_items.index(settings.output_type)
+        )
 
     choice = output_menu.show()
     click.echo(output_type_items)

--- a/cli/output.py
+++ b/cli/output.py
@@ -4,6 +4,8 @@ from termcolor import colored
 from simple_term_menu import TerminalMenu
 from cli import utils
 
+from scraper.components import manager
+
 
 def get_menu():
     return [
@@ -43,18 +45,15 @@ def out_type_descr():
 def handle_output_type(settings):
     utils.pre_menu(settings, "Change output Type", out_type_descr())
 
-    output_type_items = [
-        (settings.OUTPUT_TYPE.SINGLE_FILE, "Aggregate file"),
-        (settings.OUTPUT_TYPE.SINGLE_TICKER, "Ticker files"),
-        (None, utils.BACK_TXT)
-    ]
+    output_type_items = (utils.BACK_TXT, *manager.get_outputs())
 
     output_menu = TerminalMenu(
-        menu_entries=[txt for (_, txt) in output_type_items]
-        )
+        menu_entries=[option for option in output_type_items])
+
     choice = output_menu.show()
+    click.echo(output_type_items)
     try:
-        settings.output_type = output_type_items[choice][0]
+        settings.output_type = output_type_items[choice]
     except Exception:
         pass
 
@@ -68,13 +67,16 @@ def csv_dialect_desc():
 def handle_csv_dialect(settings):
     utils.pre_menu(settings, "Change CSV format", csv_dialect_desc())
 
-    csv_format_items = [
+    # TODO: Refactor with autogeneration from manager/settings
+    # similar on how the other menus are created. This requires refactoring
+    # the manager to include handling the of dialects and their options.
+    csv_format_items = (
+        (None, utils.BACK_TXT),
         (settings.CSV_OUT_DIALECTS.DEFAULT, "Default  pipe as delimiter"),
         (settings.CSV_OUT_DIALECTS.EXCEL, "Excel    comma as delimiter"),
-        (None, utils.BACK_TXT)
-    ]
+    )
     csv_menu = TerminalMenu(
-        menu_entries=[txt for (_, txt) in csv_format_items]
+        menu_entries=(txt for (_, txt) in csv_format_items)
         )
     choice = csv_menu.show()
     try:

--- a/cli/output.py
+++ b/cli/output.py
@@ -46,18 +46,15 @@ def out_type_descr():
 def handle_output_type(settings):
     utils.pre_menu(settings, "Change output Type", out_type_descr())
 
-    output_type_items = [
-        (settings.OUTPUT_TYPE.SINGLE_FILE, "Aggregate file"),
-        (settings.OUTPUT_TYPE.SINGLE_TICKER, "Ticker files"),
-        (None, utils.BACK_TXT)
-    ]
+    output_type_items = (utils.BACK_TXT, *manager.get_outputs())
 
     output_menu = TerminalMenu(
-        menu_entries=[txt for (_, txt) in output_type_items]
-        )
+        menu_entries=[option for option in output_type_items])
+
     choice = output_menu.show()
+    click.echo(output_type_items)
     try:
-        settings.output_type = output_type_items[choice][0]
+        settings.output_type = output_type_items[choice]
     except Exception:
         pass
 

--- a/cli/output.py
+++ b/cli/output.py
@@ -1,8 +1,11 @@
+import csv
 import time
 import click
 from termcolor import colored
 from simple_term_menu import TerminalMenu
 from cli import utils
+
+from scraper.components import manager
 
 
 def get_menu():
@@ -68,17 +71,24 @@ def csv_dialect_desc():
 def handle_csv_dialect(settings):
     utils.pre_menu(settings, "Change CSV format", csv_dialect_desc())
 
-    csv_format_items = [
-        (settings.CSV_OUT_DIALECTS.DEFAULT, "Default  pipe as delimiter"),
-        (settings.CSV_OUT_DIALECTS.EXCEL, "Excel    comma as delimiter"),
-        (None, utils.BACK_TXT)
-    ]
+    # add default dialects since they are available
+    csv_format_items = (
+        utils.BACK_TXT,
+        *manager.get_dialects_list(),
+        *csv.list_dialects()
+    )
+
     csv_menu = TerminalMenu(
-        menu_entries=[txt for (_, txt) in csv_format_items]
+        menu_entries=csv_format_items,
+        cursor_index=csv_format_items.index(settings.csv_out_dialect)
         )
     choice = csv_menu.show()
+
+    if choice == utils.BACK:
+        return False
+
     try:
-        settings.csv_out_dialect = csv_format_items[choice][0]
+        settings.csv_out_dialect = csv_format_items[choice]
     except Exception:
         pass
 

--- a/cli/output.py
+++ b/cli/output.py
@@ -10,11 +10,11 @@ from scraper.components import manager
 
 def get_menu():
     return [
+        ("[x] Back", utils.handle_go_back),
         ("[t] Change output file type", handle_output_type),
         ("[p] Change output path", handle_output_path),
         ("[f] Change output file format", handle_output_filename),
         ("[d] Change CSV format", handle_csv_dialect),
-        ("[x] Back", utils.handle_go_back),
     ]
 
 

--- a/cli/sources.py
+++ b/cli/sources.py
@@ -3,6 +3,8 @@ import click
 from simple_term_menu import TerminalMenu
 from cli import utils
 
+from scraper.components import manager
+
 
 def get_menu():
     return [
@@ -35,16 +37,16 @@ def get_sources_menu(settings, insert_mode):
 
     if insert_mode:
         # remove the already present sources from the list
-        all_sources = settings.SOURCES.VALID
-        sources = sorted(list(set(all_sources) - set(selected_sources)))
+        all_sources = manager.get_sources()
+        sources = set(all_sources) ^ set(selected_sources)
     else:
         # use the currently selected sources as list
-        sources = sorted(selected_sources)
+        sources = selected_sources
 
-    has_content = sources and len(sources) > 0
+    has_content = len(sources) > 0
 
     menu = TerminalMenu(
-        sources + [utils.BACK_TXT],
+        (utils.BACK_TXT, *sources),
         multi_select=True,
         show_multi_select_hint=True,
     )

--- a/cli/sources.py
+++ b/cli/sources.py
@@ -6,9 +6,9 @@ from cli import utils
 
 def get_menu():
     return [
+        ("[x] Back", utils.handle_go_back),
         ("[a] Add sources", handle_add_sources),
         ("[r] Remove sources", handle_remove_source),
-        ("[x] Back", utils.handle_go_back),
     ]
 
 

--- a/cli/tickers.py
+++ b/cli/tickers.py
@@ -28,7 +28,7 @@ def add_tickers_descr():
     return (f"Type the {ticker}/{symbol} you are interested in, spearated"
             f" by a space.\nIf a ticker does not exist or is typed {wrong}"
             "it will be skipped.\n\n"
-            f"To exit in case of an error type a {space} and confirm.")
+            f"To exit in case of an error type a {space} and confirm.\n")
 
 
 def handle_add_tickers(settings):
@@ -41,11 +41,11 @@ def handle_add_tickers(settings):
 
 
 def rm_tickers_descr():
-    exit = utils.highlight("exit")
+    exit_ = utils.highlight("exit")
     cancel = utils.highlight(utils.BACK_TXT)
     return (f"Select the tickers you want to remove and confirm.\n"
-            f"To {exit} without changing anything"
-            f" select {cancel} at the bottom of the list")
+            f"To {exit_} without changing anything"
+            f" select {cancel} at the bottom of the list\n")
 
 
 def handle_remove_tickers(settings):

--- a/cli/tickers.py
+++ b/cli/tickers.py
@@ -54,7 +54,7 @@ def handle_remove_tickers(settings):
 
     remove_tickers_menu = TerminalMenu(
         # the Cancel is required to go back without modifying the list
-        settings.tickers + [utils.BACK_TXT],
+        (utils.BACK_TXT, *settings.tickers),
         multi_select=True,
         show_multi_select_hint=True,
     )

--- a/cli/tickers.py
+++ b/cli/tickers.py
@@ -5,10 +5,10 @@ from cli import utils
 
 def get_menu():
     return [
+        ("[x] Back", utils.handle_go_back),
         ("[a] Add ticker(s)", handle_add_tickers),
         ("[r] Remove Ticker(s)", handle_remove_tickers),
         ("[c] clear all", handle_clear_all),
-        ("[x] Back", utils.handle_go_back),
     ]
 
 

--- a/scraper/components/manager/__init__.py
+++ b/scraper/components/manager/__init__.py
@@ -12,6 +12,28 @@ __H_T_WRITER = 'writer_handler'
 # {'type': '__H_T_XXXX', 'target': 'source/out_type', 'handler': HandlerClass}
 handlers = []
 
+# {name: {arg dict}}
+csv_dialects = []
+
+
+def register_dialect(name, **kwargs):
+    """ Store a new csv dialect to be later processed. Avoid duplicates. """
+    if name in get_dialects_list():
+        raise ValueError(f'Dialect {name} already registered.')
+
+    csv_dialects.append({'name': name, 'args': kwargs})
+    return True
+
+
+def get_dialects():
+    """ Return a tuple of (name, args) for all registered dialects. """
+    return tuple(tuple(item.values()) for item in csv_dialects)
+
+
+def get_dialects_list():
+    """ Return a tuple with all the available dialect names registered. """
+    return tuple(i['name'] for i in csv_dialects)
+
 
 def _store_handler(target, handler, type_):
     print(f"Adding {type_} for {target}")
@@ -102,3 +124,4 @@ def get_all_writers():
 
 def reset():
     handlers.clear()
+    csv_dialects.clear()

--- a/scraper/components/manager/__init__.py
+++ b/scraper/components/manager/__init__.py
@@ -1,3 +1,4 @@
+import csv
 from scraper.components.manager.handler_base import HandlerBase # noqa
 from scraper.components.manager.source_handler import SourceHandler
 from scraper.components.manager.writer_handler import WriterHandler
@@ -22,6 +23,7 @@ def register_dialect(name, **kwargs):
         raise ValueError(f'Dialect {name} already registered.')
 
     csv_dialects.append({'name': name, 'args': kwargs})
+    csv.register_dialect(name, **kwargs)
     return True
 
 
@@ -124,4 +126,6 @@ def get_all_writers():
 
 def reset():
     handlers.clear()
+    for name in get_dialects_list():
+        csv.unregister_dialect(name)
     csv_dialects.clear()

--- a/scraper/components/manager/__init__.py
+++ b/scraper/components/manager/__init__.py
@@ -30,11 +30,10 @@ def _get_handler(type_, target):
     return []
 
 
-def _exists(type_, target):
-    return bool(_get_handler(type_, target))
-
-
 def _get_available(type_):
+    """
+    Returns a list of all the 'target' set for all the handlers of type_.
+    """
     return [o['target'] for o in handlers if o['type'] == type_]
 
 
@@ -50,7 +49,7 @@ def register_handler(source, fetcher_cls, parser_cls):
 
 def register_writer(output_type, writer_cls):
 
-    if output_type in get_outputs():
+    if output_type in get_outputs():  # pragma: no cover
         return None
 
     handler = WriterHandler(output_type, writer_cls)

--- a/scraper/components/manager/source_handler.py
+++ b/scraper/components/manager/source_handler.py
@@ -22,11 +22,3 @@ class SourceHandler(HandlerBase):
         self.source = source
         self.fetcher = fetcher_cls
         self.parser = parser_cls
-
-    def __eq__(self, source_name):
-        return self.source == source_name
-
-    def __del__(self):
-        self.fetcher and self.fetcher
-        self.parser and self.parser
-        del self

--- a/scraper/components/manager/writer_handler.py
+++ b/scraper/components/manager/writer_handler.py
@@ -15,10 +15,3 @@ class WriterHandler(HandlerBase):
 
         self.output_type = type_
         self.writer = writer_cls
-
-    def __eq__(self, output_type):
-        return self.output_type == output_type
-
-    def __del__(self):
-        self.writer and self.writer
-        del self

--- a/scraper/components/writers/base_writer.py
+++ b/scraper/components/writers/base_writer.py
@@ -2,7 +2,6 @@ import abc
 import csv
 from pathlib import Path
 
-from scraper import utils
 from scraper.components.component_base import ComponentBase
 from scraper.components.writers.filename import FilenameGenerator
 
@@ -20,8 +19,6 @@ class Writer(ComponentBase):
     def write_to_file(self, path, filename, data):
         # ensure path exists and create it if missing
         Path(path).mkdir(parents=True, exist_ok=True)
-        # add our custom dialects (available should be 'excel' and 'default')
-        utils.register_custom_csv_dialects(manager.get_dialects())
 
         with open(path + filename, "w", newline="") as csvfile:
             wr = csv.writer(csvfile, dialect=self.settings.csv_out_dialect)
@@ -29,11 +26,3 @@ class Writer(ComponentBase):
                 wr.writerow(line)
 
         return True
-
-# FIXME: Refactor things around to avoid this ugly import.
-# Manager classes at some point require component base classes so
-# this causes circular imports and break stuff. For now putting it at the end
-# works, but indicates flaws in the structure.
-# IDEA: refactor _everything_ to provide manager to all components when
-# instantiating them?
-from scraper.components import manager  # noqa

--- a/scraper/components/writers/base_writer.py
+++ b/scraper/components/writers/base_writer.py
@@ -21,7 +21,7 @@ class Writer(ComponentBase):
         # ensure path exists and create it if missing
         Path(path).mkdir(parents=True, exist_ok=True)
         # add our custom dialects (available should be 'excel' and 'default')
-        utils.register_custom_csv_dialects()
+        utils.register_custom_csv_dialects(manager.get_dialects())
 
         with open(path + filename, "w", newline="") as csvfile:
             wr = csv.writer(csvfile, dialect=self.settings.csv_out_dialect)
@@ -29,3 +29,11 @@ class Writer(ComponentBase):
                 wr.writerow(line)
 
         return True
+
+# FIXME: Refactor things around to avoid this ugly import.
+# Manager classes at some point require component base classes so
+# this causes circular imports and break stuff. For now putting it at the end
+# works, but indicates flaws in the structure.
+# IDEA: refactor _everything_ to provide manager to all components when
+# instantiating them?
+from scraper.components import manager  # noqa

--- a/scraper/settings/constants.py
+++ b/scraper/settings/constants.py
@@ -45,5 +45,8 @@ class SOURCES(CONSTANT):
 class CSV_OUT_DIALECTS(CONSTANT):
     Exception = exceptions.DialectException
     DEFAULT = "default"
+    # csv default dialects
     EXCEL = "excel"
-    VALID = [DEFAULT, EXCEL]
+    EXCEL_TAB = "excel-tab"
+    UNIX = "unix"
+    VALID = [DEFAULT, EXCEL, EXCEL_TAB, UNIX]

--- a/scraper/settings/exceptions.py
+++ b/scraper/settings/exceptions.py
@@ -1,6 +1,3 @@
-from scraper.settings import constants
-
-
 class SettingsException(ValueError):
     def __str__(self):
         return self.message
@@ -44,3 +41,7 @@ class FileReadError(SettingsException):
 class MissingSourcesException(Exception):
     def __str__(self):
         return 'No Source is selected. Cannot run'
+
+
+# FIXME: refactor. see base_writer.py
+from scraper.settings import constants  # noqa

--- a/scraper/settings/exceptions.py
+++ b/scraper/settings/exceptions.py
@@ -43,5 +43,7 @@ class MissingSourcesException(Exception):
         return 'No Source is selected. Cannot run'
 
 
-# FIXME: refactor. see base_writer.py
+# FIXME: Refactor things around to avoid this ugly import.
+# This is a temporary fix to a circular import issue that randomly appeared
+# between constants and exceptions. Will be fixed later on
 from scraper.settings import constants  # noqa

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -1,5 +1,5 @@
 import csv
-from scraper.settings import constants
+# from scraper.settings import constants
 
 
 def path_contains_filename(path):
@@ -8,9 +8,15 @@ def path_contains_filename(path):
     return False
 
 
-def register_custom_csv_dialects():
-    csv.register_dialect(
-        constants.CSV_OUT_DIALECTS.DEFAULT,
-        delimiter="|",
-        quoting=csv.QUOTE_MINIMAL
-    )
+# def register_custom_csv_dialects():
+#     csv.register_dialect(
+#         constants.CSV_OUT_DIALECTS.DEFAULT,
+#         delimiter="|",
+#         quoting=csv.QUOTE_MINIMAL
+#     )
+
+
+# TODO: Replace original function, this is just for testing purpose
+def register_custom_csv_dialects(data):
+    for name, args in data:
+        csv.register_dialect(name, **args)

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -6,17 +6,3 @@ def path_contains_filename(path):
     if path[-4:] in ['.csv', '.txt']:
         return True
     return False
-
-
-# def register_custom_csv_dialects():
-#     csv.register_dialect(
-#         constants.CSV_OUT_DIALECTS.DEFAULT,
-#         delimiter="|",
-#         quoting=csv.QUOTE_MINIMAL
-#     )
-
-
-# TODO: Replace original function, this is just for testing purpose
-def register_custom_csv_dialects(data):
-    for name, args in data:
-        csv.register_dialect(name, **args)

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -1,6 +1,3 @@
-import csv
-# from scraper.settings import constants
-
 
 def path_contains_filename(path):
     if path[-4:] in ['.csv', '.txt']:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,3 +1,4 @@
+import csv
 import pytest
 from scraper.components import manager, fetchers, parsers, writers
 from scraper.settings import constants
@@ -76,11 +77,16 @@ def test_manager_writers():
 def test_manager_dialects():
     assert manager.get_dialects() == ()
     manager.register_dialect('test', delimiter='|')
+
+    assert 'test' in csv.list_dialects()
+
     # duplicates not allowed by name
     with pytest.raises(ValueError):
         manager.register_dialect('test', delimiter=',')
 
-    out = manager.get_dialects()
-    assert out == (('test', {'delimiter': '|'}), )
+    assert manager.get_dialects() == (('test', {'delimiter': '|'}), )
 
     assert manager.get_dialects_list() == ('test',)
+
+    manager.reset()
+    assert manager.get_dialects() == ()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -79,7 +79,7 @@ def test_manager_dialects():
     # duplicates not allowed by name
     with pytest.raises(ValueError):
         manager.register_dialect('test', delimiter=',')
-    
+
     out = manager.get_dialects()
     assert out == (('test', {'delimiter': '|'}), )
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -39,6 +39,7 @@ def test_manager_registration():
     h = manager.register_handler(
         constants.SOURCES.FINRA_SHORTS, fetchers.Finra, parsers.Finra)
     assert manager.get_all_handlers() == [h]
+    # test duplication of handler
     manager.register_handler(
         constants.SOURCES.FINRA_SHORTS, fetchers.Finra, parsers.Finra)
     assert manager.get_all_handlers() == [h]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -35,13 +35,13 @@ def test_handler_exceptions():
 
 @utils.decorators.manager_decorator
 def test_manager_registration():
-    assert manager.registered_handlers == []
+    assert manager.get_all_handlers() == []
     h = manager.register_handler(
         constants.SOURCES.FINRA_SHORTS, fetchers.Finra, parsers.Finra)
-    assert manager.registered_handlers == [h]
+    assert manager.get_all_handlers() == [h]
     manager.register_handler(
         constants.SOURCES.FINRA_SHORTS, fetchers.Finra, parsers.Finra)
-    assert manager.registered_handlers == [h]
+    assert manager.get_all_handlers() == [h]
 
 
 @utils.decorators.manager_decorator
@@ -58,10 +58,10 @@ def test_manager_get_handler():
 
 @utils.decorators.manager_decorator
 def test_manager_writers():
-    assert manager.registered_writers == []
+    assert manager.get_all_writers() == []
     handler = manager.register_writer(
         constants.OUTPUT_TYPE.SINGLE_FILE, writers.SingleFile)
-    assert manager.registered_writers == [handler]
+    assert manager.get_all_writers() == [handler]
 
     with pytest.raises(Exception):
         manager.get_writer(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -70,3 +70,17 @@ def test_manager_writers():
 
     assert manager.get_writer(
         constants.OUTPUT_TYPE.SINGLE_FILE) == handler.writer
+
+
+@utils.decorators.manager_decorator
+def test_manager_dialects():
+    assert manager.get_dialects() == ()
+    manager.register_dialect('test', delimiter='|')
+    # duplicates not allowed by name
+    with pytest.raises(ValueError):
+        manager.register_dialect('test', delimiter=',')
+    
+    out = manager.get_dialects()
+    assert out == (('test', {'delimiter': '|'}), )
+
+    assert manager.get_dialects_list() == ('test',)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,21 +92,17 @@ def get_fake_response(source, index):
 
 # manager utilitites & decorators functions
 # ----------------------------------------------------------------------------
-
 def _manager_save_temp():
     """Closure to ensure that the previous state is kept, since this is a
     singleton. Should not matter but better safe than sorry
     """
-    temp_handlers = list(manager.registered_handlers)
-    temp_sources = list(manager.available_sources)
-    temp_writers = list(manager.registered_writers)
-    temp_outputs = list(manager.available_outputs)
+    # Generate a new tuple to copy object and avoid references to old ones.
+    temps = tuple(
+        (o['target'], o['handler'], o['type']) for o in manager.handlers)
 
     def restore():
-        manager.registered_handlers = temp_handlers
-        manager.available_sources = temp_sources
-        manager.registered_writers = temp_writers
-        manager.available_outputs = temp_outputs
+        for item in temps:
+            manager._store_handler(*item)
 
     return restore
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,7 +105,7 @@ def _manager_save_temp():
         for item in temps_h:
             manager._store_handler(*item)
         for name, args in temp_d:
-            manager.register_dialect(name, args)
+            manager.register_dialect(name, **args)
 
     return restore
 
@@ -207,3 +207,11 @@ class decorators:
                 method(*args, header=parser.header, data=parser.data, **kwargs)
             return wrapper
         return writer_data__decorator
+
+    def register_dialect(name='default', options={'delimiter': '|'}):
+        def decorator(method):
+            def wrapped(*args, **kwargs):
+                manager.register_dialect(name, **options)
+                return method(*args, **kwargs)
+            return wrapped
+        return decorator

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,12 +97,15 @@ def _manager_save_temp():
     singleton. Should not matter but better safe than sorry
     """
     # Generate a new tuple to copy object and avoid references to old ones.
-    temps = tuple(
+    temps_h = tuple(
         (o['target'], o['handler'], o['type']) for o in manager.handlers)
+    temp_d = manager.get_dialects()
 
     def restore():
-        for item in temps:
+        for item in temps_h:
             manager._store_handler(*item)
+        for name, args in temp_d:
+            manager.register_dialect(name, args)
 
     return restore
 


### PR DESCRIPTION
Removes the need to manually edit the cli menus and options, retrieveing relevant data (the options names like sources and output type) from the ones registered in the manager.

This **will** allow to add _random_ and not known handlers to the app, when the internal validation in the settings is removed in the future