### PR TITLE
Feature/manager dialects

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -18,6 +18,8 @@ def start():
     manager.register_writer(
         OUTPUT_TYPE.SINGLE_TICKER, writers.MultiFile)
 
+    manager.register_dialect('default', delimiter='|')
+
     settings = Settings()
 
     os.system('clear')

--- a/cli/output.py
+++ b/cli/output.py
@@ -84,7 +84,7 @@ def handle_csv_dialect(settings):
         )
     choice = csv_menu.show()
 
-    if choice == utils.BACK:
+    if choice == utils.BACK_TXT:
         return False
 
     try:

--- a/cli/output.py
+++ b/cli/output.py
@@ -1,8 +1,11 @@
+import csv
 import time
 import click
 from termcolor import colored
 from simple_term_menu import TerminalMenu
 from cli import utils
+
+from scraper.components import manager
 
 
 def get_menu():
@@ -68,17 +71,24 @@ def csv_dialect_desc():
 def handle_csv_dialect(settings):
     utils.pre_menu(settings, "Change CSV format", csv_dialect_desc())
 
-    csv_format_items = [
-        (settings.CSV_OUT_DIALECTS.DEFAULT, "Default  pipe as delimiter"),
-        (settings.CSV_OUT_DIALECTS.EXCEL, "Excel    comma as delimiter"),
-        (None, utils.BACK_TXT)
-    ]
+    # add default dialects since they are available
+    csv_format_items = (
+        utils.BACK_TXT,
+        *manager.get_dialects_list(),
+        *csv.list_dialects()
+    )
+
     csv_menu = TerminalMenu(
-        menu_entries=[txt for (_, txt) in csv_format_items]
+        menu_entries=csv_format_items,
+        cursor_index=csv_format_items.index(settings.csv_out_dialect)
         )
     choice = csv_menu.show()
+
+    if choice == utils.BACK:
+        return False
+
     try:
-        settings.csv_out_dialect = csv_format_items[choice][0]
+        settings.csv_out_dialect = csv_format_items[choice]
     except Exception:
         pass
 

--- a/scraper/components/manager/__init__.py
+++ b/scraper/components/manager/__init__.py
@@ -12,6 +12,28 @@ __H_T_WRITER = 'writer_handler'
 # {'type': '__H_T_XXXX', 'target': 'source/out_type', 'handler': HandlerClass}
 handlers = []
 
+# {name: {arg dict}}
+csv_dialects = []
+
+
+def register_dialect(name, **kwargs):
+    """ Store a new csv dialect to be later processed. Avoid duplicates. """
+    if name in get_dialects_list():
+        raise ValueError(f'Dialect {name} already registered.')
+
+    csv_dialects.append({'name': name, 'args': kwargs})
+    return True
+
+
+def get_dialects():
+    """ Return a tuple of (name, args) for all registered dialects. """
+    return tuple(tuple(item.values()) for item in csv_dialects)
+
+
+def get_dialects_list():
+    """ Return a tuple with all the available dialect names registered. """
+    return tuple(i['name'] for i in csv_dialects)
+
 
 def _store_handler(target, handler, type_):
     print(f"Adding {type_} for {target}")
@@ -102,3 +124,4 @@ def get_all_writers():
 
 def reset():
     handlers.clear()
+    csv_dialects.clear()

--- a/scraper/components/manager/__init__.py
+++ b/scraper/components/manager/__init__.py
@@ -1,3 +1,4 @@
+import csv
 from scraper.components.manager.handler_base import HandlerBase # noqa
 from scraper.components.manager.source_handler import SourceHandler
 from scraper.components.manager.writer_handler import WriterHandler
@@ -22,6 +23,7 @@ def register_dialect(name, **kwargs):
         raise ValueError(f'Dialect {name} already registered.')
 
     csv_dialects.append({'name': name, 'args': kwargs})
+    csv.register_dialect(name, **kwargs)
     return True
 
 
@@ -124,4 +126,6 @@ def get_all_writers():
 
 def reset():
     handlers.clear()
+    for name in get_dialects_list():
+        csv.unregister_dialect(name)
     csv_dialects.clear()

--- a/scraper/components/writers/base_writer.py
+++ b/scraper/components/writers/base_writer.py
@@ -2,7 +2,6 @@ import abc
 import csv
 from pathlib import Path
 
-from scraper import utils
 from scraper.components.component_base import ComponentBase
 from scraper.components.writers.filename import FilenameGenerator
 
@@ -20,8 +19,6 @@ class Writer(ComponentBase):
     def write_to_file(self, path, filename, data):
         # ensure path exists and create it if missing
         Path(path).mkdir(parents=True, exist_ok=True)
-        # add our custom dialects (available should be 'excel' and 'default')
-        utils.register_custom_csv_dialects(manager.get_dialects())
 
         with open(path + filename, "w", newline="") as csvfile:
             wr = csv.writer(csvfile, dialect=self.settings.csv_out_dialect)
@@ -29,11 +26,3 @@ class Writer(ComponentBase):
                 wr.writerow(line)
 
         return True
-
-# FIXME: Refactor things around to avoid this ugly import.
-# Manager classes at some point require component base classes so
-# this causes circular imports and break stuff. For now putting it at the end
-# works, but indicates flaws in the structure.
-# IDEA: refactor _everything_ to provide manager to all components when
-# instantiating them?
-from scraper.components import manager  # noqa

--- a/scraper/components/writers/base_writer.py
+++ b/scraper/components/writers/base_writer.py
@@ -21,7 +21,7 @@ class Writer(ComponentBase):
         # ensure path exists and create it if missing
         Path(path).mkdir(parents=True, exist_ok=True)
         # add our custom dialects (available should be 'excel' and 'default')
-        utils.register_custom_csv_dialects()
+        utils.register_custom_csv_dialects(manager.get_dialects())
 
         with open(path + filename, "w", newline="") as csvfile:
             wr = csv.writer(csvfile, dialect=self.settings.csv_out_dialect)
@@ -29,3 +29,11 @@ class Writer(ComponentBase):
                 wr.writerow(line)
 
         return True
+
+# FIXME: Refactor things around to avoid this ugly import.
+# Manager classes at some point require component base classes so
+# this causes circular imports and break stuff. For now putting it at the end
+# works, but indicates flaws in the structure.
+# IDEA: refactor _everything_ to provide manager to all components when
+# instantiating them?
+from scraper.components import manager  # noqa

--- a/scraper/settings/constants.py
+++ b/scraper/settings/constants.py
@@ -45,5 +45,8 @@ class SOURCES(CONSTANT):
 class CSV_OUT_DIALECTS(CONSTANT):
     Exception = exceptions.DialectException
     DEFAULT = "default"
+    # csv default dialects
     EXCEL = "excel"
-    VALID = [DEFAULT, EXCEL]
+    EXCEL_TAB = "excel-tab"
+    UNIX = "unix"
+    VALID = [DEFAULT, EXCEL, EXCEL_TAB, UNIX]

--- a/scraper/settings/exceptions.py
+++ b/scraper/settings/exceptions.py
@@ -1,6 +1,3 @@
-from scraper.settings import constants
-
-
 class SettingsException(ValueError):
     def __str__(self):
         return self.message
@@ -44,3 +41,7 @@ class FileReadError(SettingsException):
 class MissingSourcesException(Exception):
     def __str__(self):
         return 'No Source is selected. Cannot run'
+
+
+# FIXME: refactor. see base_writer.py
+from scraper.settings import constants  # noqa

--- a/scraper/settings/exceptions.py
+++ b/scraper/settings/exceptions.py
@@ -43,5 +43,7 @@ class MissingSourcesException(Exception):
         return 'No Source is selected. Cannot run'
 
 
-# FIXME: refactor. see base_writer.py
+# FIXME: Refactor things around to avoid this ugly import.
+# This is a temporary fix to a circular import issue that randomly appeared
+# between constants and exceptions. Will be fixed later on
 from scraper.settings import constants  # noqa

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -1,5 +1,5 @@
 import csv
-from scraper.settings import constants
+# from scraper.settings import constants
 
 
 def path_contains_filename(path):
@@ -8,9 +8,15 @@ def path_contains_filename(path):
     return False
 
 
-def register_custom_csv_dialects():
-    csv.register_dialect(
-        constants.CSV_OUT_DIALECTS.DEFAULT,
-        delimiter="|",
-        quoting=csv.QUOTE_MINIMAL
-    )
+# def register_custom_csv_dialects():
+#     csv.register_dialect(
+#         constants.CSV_OUT_DIALECTS.DEFAULT,
+#         delimiter="|",
+#         quoting=csv.QUOTE_MINIMAL
+#     )
+
+
+# TODO: Replace original function, this is just for testing purpose
+def register_custom_csv_dialects(data):
+    for name, args in data:
+        csv.register_dialect(name, **args)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -79,7 +79,7 @@ def test_manager_dialects():
     # duplicates not allowed by name
     with pytest.raises(ValueError):
         manager.register_dialect('test', delimiter=',')
-    
+
     out = manager.get_dialects()
     assert out == (('test', {'delimiter': '|'}), )
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -70,3 +70,17 @@ def test_manager_writers():
 
     assert manager.get_writer(
         constants.OUTPUT_TYPE.SINGLE_FILE) == handler.writer
+
+
+@utils.decorators.manager_decorator
+def test_manager_dialects():
+    assert manager.get_dialects() == ()
+    manager.register_dialect('test', delimiter='|')
+    # duplicates not allowed by name
+    with pytest.raises(ValueError):
+        manager.register_dialect('test', delimiter=',')
+    
+    out = manager.get_dialects()
+    assert out == (('test', {'delimiter': '|'}), )
+
+    assert manager.get_dialects_list() == ('test',)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,7 +105,7 @@ def _manager_save_temp():
         for item in temps_h:
             manager._store_handler(*item)
         for name, args in temp_d:
-            manager.register_dialect(name, args)
+            manager.register_dialect(name, **args)
 
     return restore
 
@@ -207,3 +207,11 @@ class decorators:
                 method(*args, header=parser.header, data=parser.data, **kwargs)
             return wrapper
         return writer_data__decorator
+
+    def register_dialect(name='default', options={'delimiter': '|'}):
+        def decorator(method):
+            def wrapped(*args, **kwargs):
+                manager.register_dialect(name, **options)
+                return method(*args, **kwargs)
+            return wrapped
+        return decorator

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,12 +97,15 @@ def _manager_save_temp():
     singleton. Should not matter but better safe than sorry
     """
     # Generate a new tuple to copy object and avoid references to old ones.
-    temps = tuple(
+    temps_h = tuple(
         (o['target'], o['handler'], o['type']) for o in manager.handlers)
+    temp_d = manager.get_dialects()
 
     def restore():
-        for item in temps:
+        for item in temps_h:
             manager._store_handler(*item)
+        for name, args in temp_d:
+            manager.register_dialect(name, args)
 
     return restore
 


### PR DESCRIPTION
Added handling for dialects in manager
move actual csv dialect registration in manager
include default csv dialects in cli menu selection

# ⚠️ There is a circular import issue!

The problem appeared randomly but makes sense, and it's between `settings.constants` and `settings.exceptions`

For the moment that's solved by moving one of the imports to the bottom but it needs to be solved. Since i'm thinking about restructuring the components directory and removing the validations (see #44) for now it will have to stay like this.