### PR TITLE
Refactor settings validation into settings

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -115,26 +115,11 @@ def validate_settings(settings, echo=True):
         echo and click.echo(highlight(error, "red"))
         return False
 
-    ok = True
-    check_dates = True
+    ok = settings.validate()
+    for error in settings.errors:
+        echo_error(error)
 
-    if not settings.start_date:
-        ok = echo_error("Start date is required")
-        check_dates = False
-    if not settings.end_date:
-        ok = echo_error("End date is required")
-        check_dates = False
-    if check_dates and not validate_dates(settings):
-        ok = echo_error("Dates are in incorrect order")
-    if not settings.output_path or len(settings.output_path) == 0:
-        ok = echo_error("You need an output path")
-    if not settings.output_type:
-        ok = echo_error("Output type is missing")
-    if not settings.sources or len(settings.sources) == 0:
-        ok = echo_error("You need at least a source")
-
-    if not ok:
-        click.echo()
+    (not ok and echo) and click.echo()
     return ok
 
 

--- a/launcher/launchers.py
+++ b/launcher/launchers.py
@@ -108,12 +108,15 @@ def execute_run(app, settings, show_progress, verbose):
 
 def validate_settings(settings, path, debug):
     # TODO: Replace with method inside settings
-    if not cli.utils.validate_settings(settings, debug):
-        # TODO: Proper logging please!
-        print(f"{utils.parse_path(path)} or"
-              " arguments had issues. please check.")
+    valid = settings.validate()
+    if not valid:
+        for err in settings.errors:
+            debug and click.echo(err)
+        # # TODO: Proper logging please!
+        # print(f"{utils.parse_path(path)} or"
+        #       " arguments had issues. please check.")
         click.Abort()
-    return True
+    return valid
 
 
 def parse_start_date_arg(date, settings):

--- a/stonks/app.py
+++ b/stonks/app.py
@@ -15,6 +15,9 @@ class App:
         if len(self.settings.sources) == 0:
             raise exceptions.MissingSourcesException
 
+        if not self.settings.validate():  # pragma: no cover
+            yield False
+
         self.select_writer()
 
         for source in self.settings.sources:

--- a/stonks/components/manager/__init__.py
+++ b/stonks/components/manager/__init__.py
@@ -244,7 +244,7 @@ def get_handlers(for_source):
     handler = utils.get_handler(handlers, __H_T_SOURCE, for_source)
 
     if not handler:
-        raise Exception(
+        raise exceptions.MissingSourceHandlersException(
             "Handlers for '{}' were not registered."
             " please complain.".format(for_source))
 

--- a/stonks/components/manager/utils.py
+++ b/stonks/components/manager/utils.py
@@ -49,7 +49,7 @@ def is_handlers(obj):
 
     def mismatch(o):
         raise TypeError(
-            f'{obj.__name__} mismatch source: {obj.source} != {obj.is_for()}'
+            f'{o.__name__} mismatch source: {obj.source} != {o.is_for()}'
         )
 
     parser_match = obj.Parser.is_for() == obj.source

--- a/stonks/exceptions.py
+++ b/stonks/exceptions.py
@@ -47,8 +47,10 @@ class MissingSourcesException(Exception):
 
 
 class MissingSourceHandlersException(Exception):
-    def __init__(self):
-        self.message = "Component manager has no source handlers registered"
+    def __init__(
+            self,
+            msg="Component manager has no source handlers registered"):
+        self.message = msg
 
 
 class MissingWritersException(Exception):

--- a/stonks/settings/settings.py
+++ b/stonks/settings/settings.py
@@ -345,8 +345,8 @@ class Settings:
     def reset(self):
         self._start_date = Settings.default_start_date
         self._end_date = Settings.default_end_date
-        self._tickers = Settings.default_tickers
-        self._sources = Settings.default_sources
+        self._tickers = list(Settings.default_tickers)
+        self._sources = list(Settings.default_sources)
         self._out_type = Settings.default_out_type
         self._out_path = Settings.default_output_path
         self._csv_out_dialect = Settings.default_dialect

--- a/stonks/settings/settings.py
+++ b/stonks/settings/settings.py
@@ -81,42 +81,26 @@ class Settings:
     def validate(self):
         ok = True
 
-        def valid_dates_order():
+        def valid_dates_order(*args):
             if not self.start_date or not self.end_date:
                 return False
             return ((self.end_date - self.start_date).days < 0)
 
-        if not self.start_date:
-            t = self.add_error("start_date", "Start date is required")
-            ok = ok and t
-        else:
-            self.clear_errors("start_date")
-        if not self.end_date:
-            t = self.add_error("end_date", "End date is required")
-            ok = ok and t
-        else:
-            self.clear_errors("end_date")
-        if valid_dates_order():
-            t = self.add_error("date_order", "Dates are in incorrect order")
-            ok = ok and t
-        else:
-            self.clear_errors("date_order")
-        if not self.output_path or len(self.output_path) == 0:
-            t = self.add_error("output_path", "You need an output path")
-            ok = ok and t
-        else:
-            self.clear_errors("output_path")
-        if not self.output_type:
-            t = self.add_error("output_type", "Output type is missing")
-            ok = ok and t
-        else:
-            self.clear_errors("output_type")
-        if not self.sources or len(self.sources) == 0:
-            t = self.add_error("sources", "You need at least a source")
-            ok = ok and t
-        else:
-            self.clear_errors("sources")
+        def invalid(key, msg, check=lambda x: not getattr(self, x)):
+            if check(key):
+                self.add_error(key, msg)
+                return False
+            else:
+                self.clear_errors(key)
+                return ok
 
+        ok = invalid("start_date", "Start date is required")
+        ok = invalid("end_date", "End date is required")
+        ok = invalid("output_path", "You need an output path")
+        ok = invalid("output_type", "Output type is missing")
+        ok = invalid("sources", "You need at least a source")
+        ok = invalid("date_order", "Dates are in incorrect order",
+                     valid_dates_order)
         return ok
 
     @property

--- a/stonks/settings/validation_errors.py
+++ b/stonks/settings/validation_errors.py
@@ -1,4 +1,5 @@
-class validation_errors:
+class validation_errors:  # pragma: no cover
+    """Simple class to contain and organize string for errors in settings."""
     errors = {}
 
     def reset(self):

--- a/stonks/settings/validation_errors.py
+++ b/stonks/settings/validation_errors.py
@@ -1,0 +1,20 @@
+class validation_errors:
+    errors = {}
+
+    def reset(self):
+        self.errors = {}
+
+    def add(self, key, error, debug_error):
+        if key not in self.errors:
+            self.errors[key] = {'err': error, 'dbg': debug_error}
+
+    def get(self, key=None, debug=False):
+        if not key and not debug:
+            return [e['err'] for e in self.errors.values() if not e['dbg']]
+        elif debug:
+            return [e['err'] for e in self.errors.values()]
+        # This doesn't throw
+        return self.errors.get(key)
+
+    def remove(self, key):
+        self.errors.pop(key, None)

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -1,6 +1,7 @@
 import csv
 import pytest
 from stonks.components import manager, handlers, writers
+from stonks import exceptions
 
 from tests import utils
 from tests.mocks import fake_handlers_module, fake_writers_module
@@ -164,11 +165,10 @@ def test_handlers_bulk_registration():
 
     # Wrong types on attributes, missing required attributes
     class WrongEverything:
-        Fetcher = []
+        # Fetcher = []
         derp = []
         source = 'test_source'
-
-    with pytest.raises(TypeError):
-        manager.register_handlers_from_obj(WrongEverything)
+    with pytest.raises(exceptions.MissingSourceHandlersException):
+        manager.get_handlers('test_source')
 
     assert len(manager.handlers) == 3

--- a/tests/components/test_writers.py
+++ b/tests/components/test_writers.py
@@ -1,5 +1,6 @@
 import csv
 from tests import utils
+from tests.mocks import constants
 
 from stonks.components import writers, handlers
 
@@ -25,19 +26,23 @@ TEST_DATA_SINGLE = [
 
 
 def get_default_filepath_single():
-    return utils.get_file_path("20210427-20210427_FINRA_SV_GME.csv")
+    return utils.get_file_path(
+        "20210427-20210427_FINRA_SV_GME.csv", constants.OUTPUT_DIR)
 
 
 def get_default_filepaths_multi():
     return (
-        utils.get_file_path("20210427-20210427_FINRA_SV_A.csv"),
-        utils.get_file_path("20210427-20210427_FINRA_SV_MTG.csv"),
-        utils.get_file_path("20210427-20210427_FINRA_SV_SRL.csv"),
+        utils.get_file_path(
+            "20210427-20210427_FINRA_SV_A.csv", constants.OUTPUT_DIR),
+        utils.get_file_path(
+            "20210427-20210427_FINRA_SV_MTG.csv", constants.OUTPUT_DIR),
+        utils.get_file_path(
+            "20210427-20210427_FINRA_SV_SRL.csv", constants.OUTPUT_DIR),
     )
 
 
 def get_custom_filepath_single():
-    return utils.get_file_path("custom.csv")
+    return utils.get_file_path("custom.csv", constants.OUTPUT_DIR)
 
 
 def validate_written_file(paths, header, data):
@@ -107,21 +112,4 @@ class TestMultiWriter:
 
         writer.write(header, data, handlers.finra.source)
 
-        # FIXME: This is not working for multifile. either change the validate
-        # function or set up something different
         validate_written_file(get_default_filepaths_multi(), header, data)
-
-    # @utils.decorators.delete_file(get_custom_filepath_single())
-
-    # @utils.decorators.register_components
-    # @utils.decorators.setup_component(writers.ticker_writer.Writer)
-    # @utils.decorators.writer_data(TEST_HEADER, TEST_DATA_MULTI)
-    # def test_write_custom_name(self, writer, header, data, *args, **kwargs):
-
-    #     full_path = get_custom_filepath_single()
-    #     writer.settings.output_path = full_path
-    #     writer.write(header, data, handlers.finra.source)
-
-    #     with open(full_path) as file:
-    #         assert file is not None
-    #         validate_written_file(full_path, header, data)

--- a/tests/mocks/constants.py
+++ b/tests/mocks/constants.py
@@ -4,13 +4,16 @@ from stonks.components.handlers.secftd import source as secftd_source
 
 
 MOCKS_PATHS = os.path.dirname(os.path.abspath(__file__))
+EXPECTED_DIR = os.path.join(MOCKS_PATHS, 'expected')
+SOURCES_DIR = os.path.join(MOCKS_PATHS, 'source')
+OUTPUT_DIR = os.path.join(MOCKS_PATHS, "output")
+
 SETTINGS_PATH = os.path.join(MOCKS_PATHS, "options.json")
 EMPTY_SETTINGS_PATH = os.path.join(MOCKS_PATHS, "options_empty.json")
 WRONG_SETTINGS_PATH = os.path.join(MOCKS_PATHS, "options_wrong.json")
-TEMP_JSON_FILE = os.path.join(MOCKS_PATHS, "temp.json")
-TEMP_CSV_FILE = os.path.join(MOCKS_PATHS, "temp.csv")
-EXPECTED_DIR = os.path.join(MOCKS_PATHS, 'expected')
-SOURCES_DIR = os.path.join(MOCKS_PATHS, 'source')
+
+TEMP_JSON_FILE = os.path.join(OUTPUT_DIR, "temp.json")
+TEMP_CSV_FILE = os.path.join(OUTPUT_DIR, "temp.csv")
 
 TARGET_URLS = {}
 TARGET_URLS[finra_source] = [

--- a/tests/mocks/mod_handler/__init__.py
+++ b/tests/mocks/mod_handler/__init__.py
@@ -1,4 +1,27 @@
-from tests.utils import FakeFetcher as Fetcher   # noqa
-from tests.utils import FakeParser as Parser     # noqa
+# from tests.utils import FakeFetcher as Fetcher   # noqa
+# from tests.utils import FakeParser as Parser     # noqa
+from stonks.components import FetcherBase, ParserBase
+
+
+class Fetcher(FetcherBase):
+    """Simulate an actual fetcher class with required methods"""
+    @staticmethod
+    def is_for(): return 'test_source'
+
+    def make_url(): pass
+
+
+class Parser(ParserBase):
+    """Simulate an actual parser class with required methods"""
+    @staticmethod
+    def is_for(): return 'test_source'
+
+    def process_response_to_csv(self, response): return True
+
+    def extract_ticker_from_row(self, row_data): return True
+
+    def parse_row(self, row): return True
+
+
 source = Parser.is_for()
 filename_appendix = Parser.is_for()

--- a/tests/mocks/mod_writer/__init__.py
+++ b/tests/mocks/mod_writer/__init__.py
@@ -1,3 +1,15 @@
-from tests.utils import FakeWriter as Writer   # noqa
+# from tests.utils import FakeWriter as Writer   # noqa
+from stonks.components import WriterBase
+
+
+class Writer(WriterBase):
+    @staticmethod
+    def is_for(): return 'test_output'
+
+    def set_parse_rows(self): return True
+
+    def write(self, header, data, source): return True
+
+
 output_type = Writer.is_for()
 friendly_name = Writer.is_for()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,8 +16,9 @@ RUN_FILENAMES = [
     "20210427-20210427_SEC_FTD_AMC.csv",
     "20210427-20210427_SEC_FTD_GME.csv"
 ]
-RUN_OUTPUT_DIR = os.path.join(mocks.constants.MOCKS_PATHS, 'output')
-RUN_FULLPATHS = [os.path.join(RUN_OUTPUT_DIR, f) for f in RUN_FILENAMES]
+RUN_FULLPATHS = [
+    utils.get_file_path(f, mocks.constants.OUTPUT_DIR) for f in RUN_FILENAMES
+    ]
 
 
 def test_app_init_success():
@@ -132,15 +133,19 @@ class TestApp:
 
     @utils.decorators.delete_file(*RUN_FULLPATHS)
     @utils.decorators.register_components
-    def test_app_run(self):
+    @utils.decorators.response_decorator(
+        handlers.secftd.source, make_response=False)
+    def test_app_run(self, *args, **kwargs):
         app = getApp()
 
         for done in app.run():
             assert done is True
+        assert app.settings.errors == []
 
         outputs = [
-            f for f in os.listdir(RUN_OUTPUT_DIR)
-            if os.path.isfile(os.path.join(RUN_OUTPUT_DIR, f))
+            f for f in os.listdir(mocks.constants.OUTPUT_DIR)
+            if os.path.isfile(
+                os.path.join(mocks.constants.OUTPUT_DIR, f))
         ]
 
         assert outputs == RUN_FILENAMES

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -178,13 +178,20 @@ class decorators:
         Takes an arbitrary number of FULL paths and deletes all of them before
         and after the execution of the test.
         """
+        def delete_all():
+            for path in paths:
+                delete_file(path)
+
         def delete_file__decorator(method):
             def wrapped(*args, **kwargs):
-                for path in paths:
-                    delete_file(path)
-                result = method(*args, **kwargs)
-                for path in paths:
-                    delete_file(path)
+                result = None
+                delete_all()
+                try:
+                    result = method(*args, **kwargs)
+                except Exception as e:
+                    delete_all()
+                    raise e
+                delete_all()
                 return result
             return wrapped
         return delete_file__decorator
@@ -231,7 +238,7 @@ class decorators:
         """
         def writer_data__decorator(method):
             def wrapper(*args, settings, **kwargs):
-                settings.output_path = MOCKS_PATHS
+                settings.output_path = OUTPUT_DIR
                 parser = parser_cls(settings)
                 parser.cache_header(header)
                 for row in data:
@@ -248,38 +255,39 @@ class decorators:
                 manager.register_dialect(name, **options)
                 try:
                     method(*args, **kwargs)
-                except Exception:
-                    pass
-                finally:
+                except Exception as e:
                     manager.reset()
+                    raise e
+                manager.reset()
             return wrapped
         return decorator
 
     def register_components(method):
         def wrapper(*args, **kwargs):
             manager.reset()
-            manager.register_handlers_from_modules(handlers)
-            manager.register_writers_from_module(writers)
+            manager.init(
+                skip_default=True,
+                objects=[handlers.finra, handlers.secftd,
+                         writers.ticker_writer, writers.aggregate_writer])
+
             try:
                 method(*args, **kwargs)
-            except Exception:
-                pass
-            finally:
+            except Exception as e:
                 manager.reset()
+                raise e
+            manager.reset()
         return wrapper
 
     def manager_decorator(method):
         """decorator that saves the previous state of the manager handlers,
         execute the test and then restores it after"""
         def wrapped(*args, **kwargs):
-            # restore = _manager_save_temp()
-            # clear_manager()
-            manager.reset()
+            restore = _manager_save_temp()
+            clear_manager()
             try:
                 method(*args, **kwargs)
-            except Exception:
-                pass
-            finally:
-                manager.reset()
-            # restore()
+            except Exception as e:
+                restore()
+                raise e
+            manager.reset()
         return wrapped

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,43 +8,19 @@ import responses
 from tests.mocks.constants import (
     EXPECTED_DIR,
     SOURCES_DIR,
+    OUTPUT_DIR,
     TARGET_URLS,
     DATA_FILES,
     SETTINGS_PATH,
-    MOCKS_PATHS,
 )
+from tests.mocks.mod_handler import (
+    Parser as FakeParser,
+    Fetcher as FakeFetcher,
+)
+from tests.mocks.mod_writer import Writer as FakeWriter
+
 from stonks import Settings
 from stonks.components import manager, handlers, writers
-from stonks.components import FetcherBase, ParserBase, WriterBase
-
-
-class FakeFetcher(FetcherBase):
-    """Simulate an actual fetcher class with required methods"""
-    @staticmethod
-    def is_for(): return 'test_source'
-
-    def make_url(): pass
-
-
-class FakeParser(ParserBase):
-    """Simulate an actual parser class with required methods"""
-    @staticmethod
-    def is_for(): return 'test_source'
-
-    def process_response_to_csv(self, response): return True
-
-    def extract_ticker_from_row(self, row_data): return True
-
-    def parse_row(self, row): return True
-
-
-class FakeWriter(WriterBase):
-    @staticmethod
-    def is_for(): return 'test_output'
-
-    def set_parse_rows(self): return True
-
-    def write(self, header, data, source): return True
 
 
 class FakeHandlerModule:
@@ -66,7 +42,7 @@ class WrongClass:
 
 
 def get_file_path(filename, *folders):
-    return os.path.join(MOCKS_PATHS, *folders, filename)
+    return os.path.join(*folders, filename)
 
 
 def delete_file(path):


### PR DESCRIPTION
Moved settings validation into settings class
added a small class to store unique errors from validation/actions in settings
refactor cli/launcher to use the new validation function
added missing tests

to properly push up i had to fix and clean up all the test suite since it had issues in the decorators.

The errors manager is obviously a mock but for now it does and created the interface