### PR TITLE
fix index error on base_parser

### DIFF
--- a/cli/helpers/menu.py
+++ b/cli/helpers/menu.py
@@ -28,6 +28,9 @@ class Menu(Page):
             # the menu to fail without saying what happened.
             except TypeError:  # catch ESC key to go back
                 menu_exit = True
+            # except Exception:
             except Exception as e:
-                logger.debug(e)
+                print()
+                logger.error(e)
+                # click.pause()
                 menu_exit = True

--- a/stonks/components/base_parser.py
+++ b/stonks/components/base_parser.py
@@ -1,6 +1,7 @@
 import abc
-from stonks.components.base_component import ComponentBase
 from datetime import datetime as dt
+
+from stonks.components.base_component import ComponentBase
 
 # To be compatible with writers cache structure should be a dictionary shaped
 # as { [TICKER]: [CSV ROWS] } and be available in self._cache
@@ -56,11 +57,17 @@ class ParserBase(ComponentBase):
 
     def parse(self, response, separator='|'):
         reader = self.process_response_to_csv(response)
+        header = next(reader)
+        # if there is no header to parse skip everything
+        if len(header) == 0:
+            return
 
         # first line is the header. cache it
-        self.cache_header(next(reader)[0].split(separator))
+        self.cache_header(header[0].split(separator))
 
         for row in reader:
+            if len(row) == 0:
+                continue
             data = row[0].split(separator)
             if len(data) <= 1:
                 continue


### PR DESCRIPTION
if the csv data is empty - may happen - the parsing fail miserably.
Check both for the header (first reader item) and for the content of each subsequent rows before trying to parse them